### PR TITLE
Add task creation form with card details

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ It runs entirely in the browser using HTML, CSS and JavaScript.
 Open `index.html` in a modern web browser. Drag tasks between columns to move them
 from **Todo** to **In Progress** and finally **Done**.
 
-An example task is provided to get started. You can edit the HTML to add more tasks
-or extend the functionality with additional JavaScript if desired.
+Use the form at the top of the page to create new tasks. Each task requires a
+title, description, the creator's name, a date and a priority color. Drag and
+drop tasks between columns to update their status. An example task is included
+to get started.
 

--- a/index.html
+++ b/index.html
@@ -8,10 +8,26 @@
 </head>
 <body>
     <h1>Kanban Todo Board</h1>
+    <form id="taskForm" class="form-container">
+        <input type="text" id="title" placeholder="Başlık" required>
+        <textarea id="description" placeholder="Açıklama" required></textarea>
+        <input type="text" id="creator" placeholder="Oluşturan Kişi" required>
+        <input type="date" id="date" required>
+        <select id="priority">
+            <option value="green">Yeşil (Düşük)</option>
+            <option value="blue">Mavi (Orta)</option>
+            <option value="red">Kırmızı (Yüksek)</option>
+        </select>
+        <button type="submit">Ekle</button>
+    </form>
     <div class="board">
         <div class="column" id="todo" ondrop="drop(event)" ondragover="allowDrop(event)">
             <h2>Todo</h2>
-            <div class="item" draggable="true" ondragstart="drag(event)">Example Task</div>
+            <div class="item green" draggable="true" ondragstart="drag(event)">
+                <div class="title">Örnek Görev</div>
+                <div class="description">Açıklama</div>
+                <div class="meta">Admin - 2023-01-01</div>
+            </div>
         </div>
         <div class="column" id="inprogress" ondrop="drop(event)" ondragover="allowDrop(event)">
             <h2>In Progress</h2>

--- a/script.js
+++ b/script.js
@@ -15,3 +15,38 @@ function drop(ev) {
         draggedItem = null;
     }
 }
+
+document.getElementById('taskForm').addEventListener('submit', function(e) {
+    e.preventDefault();
+
+    const title = document.getElementById('title').value;
+    const description = document.getElementById('description').value;
+    const creator = document.getElementById('creator').value;
+    const date = document.getElementById('date').value;
+    const priority = document.getElementById('priority').value;
+
+    const item = document.createElement('div');
+    item.classList.add('item', priority);
+    item.draggable = true;
+    item.ondragstart = drag;
+
+    const titleEl = document.createElement('div');
+    titleEl.className = 'title';
+    titleEl.textContent = title;
+
+    const descEl = document.createElement('div');
+    descEl.className = 'description';
+    descEl.textContent = description;
+
+    const metaEl = document.createElement('div');
+    metaEl.className = 'meta';
+    metaEl.textContent = `${creator} - ${date}`;
+
+    item.appendChild(titleEl);
+    item.appendChild(descEl);
+    item.appendChild(metaEl);
+
+    document.getElementById('todo').appendChild(item);
+
+    e.target.reset();
+});

--- a/style.css
+++ b/style.css
@@ -36,3 +36,47 @@ h1 {
     border-radius: 3px;
     cursor: grab;
 }
+
+.form-container {
+    width: 80%;
+    margin: 0 auto 20px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.form-container input,
+.form-container textarea,
+.form-container select,
+.form-container button {
+    padding: 5px;
+}
+
+.form-container textarea {
+    flex-basis: 100%;
+}
+
+.item .title {
+    font-weight: bold;
+}
+
+.item .description {
+    margin: 5px 0;
+}
+
+.item .meta {
+    font-size: 0.8em;
+    color: #555;
+}
+
+.item.green {
+    border-left: 5px solid #2ecc71;
+}
+
+.item.blue {
+    border-left: 5px solid #3498db;
+}
+
+.item.red {
+    border-left: 5px solid #e74c3c;
+}


### PR DESCRIPTION
## Summary
- allow creating tasks with title, description, creator, date and priority color
- show example card and render details beneath the card
- style form and priority colours
- update README for new workflow

## Testing
- `git log -2 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684027da20c083229201da8733ff0da8